### PR TITLE
Catch https errors.

### DIFF
--- a/thingspeak/thingspeak.js
+++ b/thingspeak/thingspeak.js
@@ -14,7 +14,9 @@ module.exports = function(RED) {
             node.error("Got "+response.statusCode);
           }
         }
-      );
+      ).on('error', function(e) {
+          node.error("Error posting to ThingSpeak: " + e);
+      });
     });
   }
   RED.nodes.registerType("ThingspeakSendSimple", ThingspeakSendSimple);


### PR DESCRIPTION
Here is a change that catches HTTPS and DNS resolution errors that occur when the node fails to connect to ThingSpeak.  This happens commonly when the Internet connection is down or otherwise not available.

Without this change, a connection failure causes the entire Node Red server to exit with an uncaught exception.

Fixes #2
